### PR TITLE
fix(#18): change to display same error message with keystone

### DIFF
--- a/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
+++ b/app/components/Views/RevealPrivateCredential/RevealPrivateCredential.tsx
@@ -44,7 +44,7 @@ import { Authentication } from '../../../core/';
 
 import Device from '../../../util/device';
 import { strings } from '../../../../locales/i18n';
-import { isQRHardwareAccount } from '../../../util/address';
+import { isHardwareAccount } from '../../../util/address';
 import AppConstants from '../../../core/AppConstants';
 import { createStyles } from './styles';
 import { getNavigationOptionsTitle } from '../../../components/UI/Navbar';
@@ -141,7 +141,7 @@ const RevealPrivateCredential = ({
       }
     } catch (e: any) {
       let msg = strings('reveal_credential.warning_incorrect_password');
-      if (isQRHardwareAccount(selectedAddress)) {
+      if (isHardwareAccount(selectedAddress)) {
         msg = strings('reveal_credential.hardware_error');
       } else if (
         e.toString().toLowerCase() !== WRONG_PASSWORD_ERROR.toLowerCase()


### PR DESCRIPTION
**Description**

- use isHardwareAccount instead isQRHardwareAccount

**Issue**
https://app.zenhub.com/workspaces/cet-metamask-mobile-ledger-integration-649aeabc8cdfe3878d13629f/issues/zh/18
**Actual result** (Ledger): 'Couldn't unlock you account. Please try again' 
**Expected result** (Keystone): 'This is a hardware wallet account, you cannot export your private key.'

Progresses #???

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented 

