### PR TITLE
fix(#34): incorrect label when signing transaction via browser

### DIFF
--- a/app/components/UI/ActionView/index.js
+++ b/app/components/UI/ActionView/index.js
@@ -52,6 +52,8 @@ export default function ActionView({
   style = undefined,
 }) {
   const { colors } = useTheme();
+  confirmText = confirmText || strings('action_view.confirm');
+  cancelText = cancelText || strings('action_view.cancel');
 
   return (
     <View style={baseStyles.flexGrow}>
@@ -110,9 +112,9 @@ export default function ActionView({
 }
 
 ActionView.defaultProps = {
-  cancelText: strings('action_view.cancel'),
+  cancelText: '',
   confirmButtonMode: 'normal',
-  confirmText: strings('action_view.confirm'),
+  confirmText: '',
   confirmTestID: '',
   confirmed: false,
   cancelTestID: '',


### PR DESCRIPTION
**Description**

correct label when signing transaction via browser

**Issue**

(https://app.zenhub.com/workspaces/cet-metamask-mobile-ledger-integration-649aeabc8cdfe3878d13629f/issues/zh/34)

**Checklist**

* [ ] There is a related GitHub issue
* [ ] Tests are included if applicable
* [ ] Any added code is fully documented
