### PR TITLE
fix (#17): Unknown labels on transaction screen for MetaMask and imported accounts

### DIFF
--- a/app/components/UI/AddressInputs/index.js
+++ b/app/components/UI/AddressInputs/index.js
@@ -589,7 +589,8 @@ export const AddressFrom = (props) => {
     fromAccountAddress,
     layout = 'horizontal',
   } = props;
-  const isImportedOrHardwareAccount = getAddressAccountType(fromAccountAddress);
+  const isImportedOrHardwareAccount =
+    getAddressAccountType(fromAccountAddress) !== 'MetaMask';
   const accountLabel = isImportedOrHardwareAccount
     ? getLabelTextByAddress(fromAccountAddress)
     : '';


### PR DESCRIPTION
**Description**

Fixed unknown labels on transactions for MM accounts by removing any label display for these kind of accounts